### PR TITLE
Add script to batch process raw data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ brew install poppler tesseract ffmpeg
 
 #### 1.4. Run the Data Processing Pipeline
 
-Place your raw data (PDFs, images, audio, video, text files, or a list of URLs for websites) into the `raw_data/` directory. Then, you can run the `orchestrator.py` script to process your data. The `test_pipeline.py` script provides an example of how to use the orchestrator.
+Place your raw data (PDFs, images, audio, video, text files, or a list of URLs for websites) into the `raw_data/` directory. The repository now includes a convenience script that will iterate over everything in this folder and process it automatically.
 
-To run the example data processing pipeline:
+To run the data processing pipeline on all files in `raw_data/`:
 
 ```bash
-python3 scripts/test_pipeline.py
+python3 scripts/process_raw_data.py
 ```
 
-This will process the sample data in `raw_data/` and save the processed outputs in `processed_data/`.
+This script detects the file type (PDF, image, audio, video, or text) and calls the orchestrator accordingly. Processed outputs are saved in `processed_data/`, and metadata is written to `processed_data/processed_data_metadata.json`.
 
-To process your own data, you will need to modify `scripts/test_pipeline.py` or create a new script that calls the `process_data_source` function from `scripts/orchestrator.py` with your specific data paths and types.
+`scripts/test_pipeline.py` remains as a simple example showing how to call `process_data_source` directly if you need more control or want to integrate specific sources (like websites) manually.
 
 ### 2. LLM Training
 

--- a/scripts/process_raw_data.py
+++ b/scripts/process_raw_data.py
@@ -1,0 +1,47 @@
+import os
+import logging
+
+from scripts.orchestrator import process_data_source
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+SUPPORTED_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".bmp", ".tiff"}
+SUPPORTED_AUDIO_EXTS = {".mp3", ".wav", ".flac", ".ogg", ".m4a"}
+SUPPORTED_VIDEO_EXTS = {".mp4", ".avi", ".mov", ".mkv"}
+
+
+def detect_source_type(file_path: str):
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext == ".pdf":
+        return "pdf"
+    if ext in SUPPORTED_IMAGE_EXTS:
+        return "image"
+    if ext == ".txt":
+        return "text_file"
+    if ext in SUPPORTED_AUDIO_EXTS:
+        return "audio"
+    if ext in SUPPORTED_VIDEO_EXTS:
+        return "video"
+    return None
+
+
+def process_all_raw_data(raw_data_dir: str = "./raw_data", processed_data_dir: str = "./processed_data"):
+    metadata_file = os.path.join(processed_data_dir, "processed_data_metadata.json")
+    os.makedirs(processed_data_dir, exist_ok=True)
+
+    for name in os.listdir(raw_data_dir):
+        path = os.path.join(raw_data_dir, name)
+        if not os.path.isfile(path):
+            continue
+        source_type = detect_source_type(path)
+        if not source_type:
+            logging.warning(f"Skipping unsupported file type: {path}")
+            continue
+        logging.info(f"Processing {path} as {source_type}")
+        process_data_source(path, source_type, processed_data_dir, metadata_file)
+
+    logging.info("Processing complete.")
+
+
+if __name__ == "__main__":
+    process_all_raw_data()

--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -95,8 +95,10 @@ if __name__ == "__main__":
         "--processed_data_path",
         type=str,
         required=True,
-        help="Path to the directory containing processed text data (e.g., processed_data/processed_text).
-        Each .txt file in this directory will be treated as a document.",
+        help=(
+            "Path to the directory containing processed text data (e.g., processed_data/processed_text). "
+            "Each .txt file in this directory will be treated as a document."
+        ),
     )
     parser.add_argument(
         "--model_name",


### PR DESCRIPTION
## Summary
- add `process_raw_data.py` to automatically iterate over files in `raw_data/`
- document new script usage in README
- fix multiline argument string in `train_llm.py`

## Testing
- `python3 -m py_compile scripts/process_raw_data.py`
- `python3 -m py_compile scripts/train_llm.py`
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687896ae1840832b9589a98250a5b735