### PR TITLE
Add multi-audio-text pair processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,37 @@ python3 scripts/process_raw_data.py
 
 This script detects the file type (PDF, image, audio, video, or text) and calls the orchestrator accordingly. Processed outputs are saved in `processed_data/`, and metadata is written to `processed_data/processed_data_metadata.json`.
 
+#### Example: Processing an Audio/Text Pair Directory
+
+If you have a folder containing multiple audio files with matching transcript
+files, you can process the entire directory at once. The audio and text files
+must share the same base filename, such as `sample1.wav` and `sample1.txt`.
+
+```
+raw_data/test_audio_pairs/
+├── sample1.wav
+├── sample1.txt
+├── sample2.wav
+└── sample2.txt
+```
+
+To process this directory manually using the orchestrator:
+
+```python
+from scripts.orchestrator import process_data_source
+
+process_data_source(
+    "./raw_data/test_audio_pairs",
+    "audio_text_pair",
+    "./processed_data",
+    "./processed_data/processed_data_metadata.json",
+)
+```
+
+Each detected pair will appear in `processed_data_metadata.json` with a
+`pair_id` linking the processed audio segments to the corresponding transcript
+file, enabling easy alignment for STT model training.
+
 `scripts/test_pipeline.py` remains as a simple example showing how to call `process_data_source` directly if you need more control or want to integrate specific sources (like websites) manually.
 
 ### 2. LLM Training
@@ -179,7 +210,7 @@ Place your raw, unprocessed data files into the `raw_data/` directory. The pipel
 *   **Audio Files (`.mp3`, `.wav`, `.flac`, etc.)**: Audio recordings for transcription or further audio processing.
 *   **Video Files (`.mp4`, `.avi`, `.mov`, etc.)**: Video files from which audio tracks can be extracted.
 *   **Text Files (`.txt`)**: Plain text documents.
-*   **Audio-Text Pairs (directory)**: A directory containing an audio file and a text file with the transcript. The directory should contain one audio file and one text file.
+*   **Audio-Text Pairs (directory)**: A directory containing one or more audio files and matching `.txt` transcripts that share the same base filename (e.g. `sample.wav` and `sample.txt`).
 *   **Website URLs**: You can provide a list of URLs (static or dynamic) within a text file, or directly pass them to the `process_data_source` function.
 
 ### Expected Output (`processed_data/`)
@@ -189,7 +220,8 @@ After running the data processing pipeline, the `processed_data/` directory will
 *   `processed_data/processed_text/`: Contains `.txt` files with extracted and cleaned text from PDFs, images, text files, and websites. Each file will correspond to a processed text source.
 *   `processed_data/processed_audio/`: Contains `.wav` files of standardized audio segments extracted from raw audio files.
 *   `processed_data/processed_audio_from_video/`: Contains `.wav` files of standardized audio segments extracted from video files.
-*   `processed_data/processed_data_metadata.json`: A JSON file that stores metadata for all processed items, including their original source, hash (for deduplication), processed path, data type, and timestamp. This file is crucial for tracking processed data and preventing duplicates.
+*   `processed_data/audio_text_pair_template.txt`: Describes how processed audio/text pairs are structured.
+*   `processed_data/processed_data_metadata.json`: A JSON file that stores metadata for all processed items, including their original source, hash (for deduplication), processed path, data type, and timestamp. This file is crucial for tracking processed data and preventing duplicates. When processing audio-text pair folders, each entry includes a `pair_id` linking an audio file to its transcript.
 
 ## Using Processed Data for LLM Training
 

--- a/processed_data/audio_text_pair_template.txt
+++ b/processed_data/audio_text_pair_template.txt
@@ -1,0 +1,2 @@
+This directory contains examples of processed audio-text pairs. Each audio file has a matching text file with the same base name.
+The metadata file links each pair using the "pair_id" field so STT systems can easily align audio with its transcript.

--- a/processed_data/processed_data_metadata.json
+++ b/processed_data/processed_data_metadata.json
@@ -33,21 +33,33 @@
         "timestamp": "2025-06-20T10:00:00Z"
     },
     {
-        "source_type": "audio_text_pair",
-        "original_source": "./raw_data/audio_text_pair",
-        "processed_audio_paths": [
-            "./processed_data/processed_audio/sample_audio_segment_0.wav"
-        ],
-        "processed_text_path": "./processed_data/processed_text/sample_transcript_text_file.txt",
-        "data_type": "audio_text_aligned",
-        "timestamp": "2025-06-20T10:00:00Z"
-    },
-    {
         "source_type": "image",
         "original_source": "./raw_data/RUNYORO-RUTOORO-RADIO-SCRIPT.png",
         "original_source_hash": "2faee553aae8adc099bee117bdf61637",
         "processed_path": "./processed_data/processed_text/RUNYORO-RUTOORO-RADIO-SCRIPT_image.txt",
         "data_type": "text",
+        "timestamp": "2025-06-20T10:00:00Z"
+    },
+    {
+        "source_type": "audio_text_pair",
+        "original_source": "./raw_data/test_audio_pairs",
+        "pair_id": "sample1",
+        "processed_audio_paths": [
+            "./processed_data/processed_audio/sample1_segment_0.wav"
+        ],
+        "processed_text_path": "./processed_data/processed_text/sample1_text_file.txt",
+        "data_type": "audio_text_aligned",
+        "timestamp": "2025-06-20T10:00:00Z"
+    },
+    {
+        "source_type": "audio_text_pair",
+        "original_source": "./raw_data/test_audio_pairs",
+        "pair_id": "sample2",
+        "processed_audio_paths": [
+            "./processed_data/processed_audio/sample2_segment_0.wav"
+        ],
+        "processed_text_path": "./processed_data/processed_text/sample2_text_file.txt",
+        "data_type": "audio_text_aligned",
         "timestamp": "2025-06-20T10:00:00Z"
     }
 ]

--- a/processed_data/processed_text/test_audio_pairs_sample1_text_file.txt
+++ b/processed_data/processed_text/test_audio_pairs_sample1_text_file.txt
@@ -1,0 +1,1 @@
+Hello world (processed)

--- a/processed_data/processed_text/test_audio_pairs_sample2_text_file.txt
+++ b/processed_data/processed_text/test_audio_pairs_sample2_text_file.txt
@@ -1,0 +1,1 @@
+Goodbye world (processed)

--- a/raw_data/test_audio_pairs/sample1.txt
+++ b/raw_data/test_audio_pairs/sample1.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/raw_data/test_audio_pairs/sample2.txt
+++ b/raw_data/test_audio_pairs/sample2.txt
@@ -1,0 +1,1 @@
+Goodbye world

--- a/scripts/audio_text_processing.py
+++ b/scripts/audio_text_processing.py
@@ -6,43 +6,65 @@ from scripts.text_processing import process_text_source
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
-def process_audio_text_pair(directory_path, output_base_dir, segment_params=None):
-    logging.info(f"Processing audio-text pair from directory: {directory_path}")
+def process_audio_text_pairs(directory_path, output_base_dir, segment_params=None):
+    """Process a directory containing multiple audio/text pairs.
+
+    Audio and transcript files must share the same base name, e.g. ``sample.wav``
+    and ``sample.txt``. Each detected pair is standardised and saved to the
+    processed data directories.
+    """
+    logging.info(f"Processing audio-text pairs from directory: {directory_path}")
 
     files = os.listdir(directory_path)
-    audio_file = None
-    text_file = None
 
     SUPPORTED_AUDIO_EXTS = {".mp3", ".wav", ".flac", ".ogg", ".m4a"}
 
+    audio_files = {}
+    text_files = {}
     for f in files:
-        ext = os.path.splitext(f)[1].lower()
+        base, ext = os.path.splitext(f)
+        ext = ext.lower()
         if ext in SUPPORTED_AUDIO_EXTS:
-            audio_file = os.path.join(directory_path, f)
+            audio_files[base] = os.path.join(directory_path, f)
         elif ext == ".txt":
-            text_file = os.path.join(directory_path, f)
+            text_files[base] = os.path.join(directory_path, f)
 
-    if not audio_file or not text_file:
-        logging.error(f"Could not find an audio and a text file in {directory_path}")
+    common_basenames = sorted(set(audio_files) & set(text_files))
+    if not common_basenames:
+        logging.error(
+            f"Could not find matching audio/text pairs in {directory_path}"
+        )
         return []
 
-    # Process audio
+    results = []
     audio_output_dir = os.path.join(output_base_dir, "processed_audio")
     os.makedirs(audio_output_dir, exist_ok=True)
-    processed_audio_segments = process_audio_source(audio_file, audio_output_dir, **(segment_params or {}))
-
-    # Process text
     text_output_dir = os.path.join(output_base_dir, "processed_text")
     os.makedirs(text_output_dir, exist_ok=True)
-    processed_text_filepath = process_text_source(text_file, 'text_file', text_output_dir)
 
-    if not processed_audio_segments or not processed_text_filepath:
-        logging.error(f"Failed to process either audio or text for {directory_path}")
-        return []
+    for base in common_basenames:
+        audio_file = audio_files[base]
+        text_file = text_files[base]
 
-    # For now, we'll just return the metadata.
-    # A more sophisticated implementation would align the audio segments with the text.
-    return {
-        "processed_audio": processed_audio_segments,
-        "processed_text": processed_text_filepath
-    }
+        processed_audio_segments = process_audio_source(
+            audio_file, audio_output_dir, **(segment_params or {})
+        )
+        processed_text_filepath = process_text_source(
+            text_file, "text_file", text_output_dir
+        )
+
+        if not processed_audio_segments or not processed_text_filepath:
+            logging.error(
+                f"Failed to process audio or text for pair '{base}' in {directory_path}"
+            )
+            continue
+
+        results.append(
+            {
+                "pair_id": base,
+                "processed_audio": processed_audio_segments,
+                "processed_text": processed_text_filepath,
+            }
+        )
+
+    return results

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -7,7 +7,7 @@ import requests
 from scripts.text_processing import process_text_source
 from scripts.audio_processing import process_audio_source
 from scripts.video_processing import process_video_source
-from scripts.audio_text_processing import process_audio_text_pair
+from scripts.audio_text_processing import process_audio_text_pairs
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
@@ -123,18 +123,21 @@ def process_data_source(source_path_or_url, source_type, output_base_dir, metada
                 "timestamp": "2025-06-20T10:00:00Z"
             })
     elif source_type == "audio_text_pair":
-        processed_pair_info = process_audio_text_pair(source_path_or_url, output_base_dir, segment_params)
-        if processed_pair_info:
-            # This is a simplified metadata entry.
-            # You might want to create more detailed entries for each audio segment and the text file.
-            processed_outputs_metadata.append({
-                "source_type": source_type,
-                "original_source": original_source_identifier,
-                "processed_audio_paths": [seg["path"] for seg in processed_pair_info["processed_audio"]],
-                "processed_text_path": processed_pair_info["processed_text"],
-                "data_type": "audio_text_aligned",
-                "timestamp": "2025-06-20T10:00:00Z"
-            })
+        processed_pairs = process_audio_text_pairs(
+            source_path_or_url, output_base_dir, segment_params
+        )
+        for pair in processed_pairs:
+            processed_outputs_metadata.append(
+                {
+                    "source_type": source_type,
+                    "original_source": original_source_identifier,
+                    "pair_id": pair["pair_id"],
+                    "processed_audio_paths": [seg["path"] for seg in pair["processed_audio"]],
+                    "processed_text_path": pair["processed_text"],
+                    "data_type": "audio_text_aligned",
+                    "timestamp": "2025-06-20T10:00:00Z",
+                }
+            )
     else:
         logging.error(f"Unknown source type: {source_type}")
 


### PR DESCRIPTION
## Summary
- support multiple audio/text pairs in a folder
- document new pair_id metadata
- remove binary audio samples from repository
- add README example for audio/text pair processing
- update test_pipeline to generate dummy audio and process audio/text pairs

## Testing
- `python3 -m py_compile scripts/audio_text_processing.py scripts/orchestrator.py scripts/process_raw_data.py scripts/test_pipeline.py`
- `pip install --quiet -r requirements.txt`
- `pip install --quiet pdf2image`
- `PYTHONPATH=. python3 scripts/test_pipeline.py` *(fails to perform OCR and website scraping due to missing tools and blocked site access, but script runs)*

------
https://chatgpt.com/codex/tasks/task_e_6879bb2bbf30832ba8aa86af8bd4631b