### PR TITLE
Add Colab notebooks for LLM training

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ file, enabling easy alignment for STT model training.
 
 `scripts/test_pipeline.py` remains as a simple example showing how to call `process_data_source` directly if you need more control or want to integrate specific sources (like websites) manually.
 
+#### Running Training Locally vs. Google Colab
+
+Data processing generally runs well on a MacBook Pro, but the first stage of
+LLM training (`scripts/train_llm.py`) can easily exhaust laptop memory.  If you
+see crashes during training, switch to Google Colab or another GPU-enabled
+environment.  This repository now provides Colab notebooks under
+`notebooks/` that automate the heavy training step.  After training finishes you
+can copy the `models/` directory back to your MacBook and continue with local
+testing or further fine‑tuning.
+
 ### 2. LLM Training
 
 Once your data has been processed and is available in `processed_data/processed_text/`, you can proceed with training your LLM.
@@ -184,12 +194,10 @@ For cloud environments, the setup process is similar but often simpler due to pr
     !cp -r "/content/drive/MyDrive/path/to/your/raw_data/*" raw_data/
     ```
     Alternatively, upload directly to the `raw_data/` directory.
-6.  **Run the Pipeline (Processing, Training, Testing)**: Execute the scripts as described in sections 1.4, 2.1, and 3.1:
-    ```python
-    !python3 scripts/test_pipeline.py # For data processing
-    !python3 scripts/train_llm.py --processed_data_path ./processed_data/processed_text --model_name gpt2 --output_dir ./models/runyoro_llm_model
-    !python3 scripts/test_llm.py --model_path ./models/runyoro_llm_model/final_model --prompt "Ekiro kyona"
-    ```
+6.  **Use the Provided Notebooks**: Instead of manually running each command,
+    open the notebooks in the `notebooks/` directory (`01_Process_Data.ipynb`,
+    `02_Train_LLM_Stage1.ipynb`, and `03_Test_LLM.ipynb`).  These notebooks
+    contain the commands needed for processing, training, and testing on Colab.
 
 #### 4.2. Hugging Face Spaces
 

--- a/notebooks/01_Process_Data.ipynb
+++ b/notebooks/01_Process_Data.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Runyoro/Rutooro Data Processing\n",
+    "This notebook prepares your data for model training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Clone repository\n",
+    "!git clone https://github.com/nyacly/runyoro-llm-data-pipeline.git\n",
+    "%cd runyoro-llm-data-pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Install Python and system dependencies\n",
+    "!pip install -r requirements.txt\n",
+    "!sudo apt-get update\n",
+    "!sudo apt-get install -y poppler-utils tesseract-ocr ffmpeg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# (Optional) Mount Google Drive to access data\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Run data processing\n",
+    "!python3 scripts/process_raw_data.py"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/02_Train_LLM_Stage1.ipynb
+++ b/notebooks/02_Train_LLM_Stage1.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LLM Training - Stage 1\n",
+    "Run the initial training of the model using GPU resources from Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Clone repository if not already cloned\n",
+    "!git clone https://github.com/nyacly/runyoro-llm-data-pipeline.git || true\n",
+    "%cd runyoro-llm-data-pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "!pip install -r requirements.txt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Mount Google Drive to load processed data and save models\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Adjust the paths below if your data/model directories are in Drive\n",
+    "!python3 scripts/train_llm.py \\
+        --processed_data_path ./processed_data/processed_text \\
+        --model_name gpt2 \\
+        --output_dir ./models/runyoro_llm_model"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/03_Test_LLM.ipynb
+++ b/notebooks/03_Test_LLM.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test Trained LLM\n",
+    "Generate text from the model trained in the previous step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Clone repository if needed\n",
+    "!git clone https://github.com/nyacly/runyoro-llm-data-pipeline.git || true\n",
+    "%cd runyoro-llm-data-pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "!pip install -r requirements.txt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Load the model and generate text\n",
+    "!python3 scripts/test_llm.py \\
+        --model_path ./models/runyoro_llm_model/final_model \\
+        --prompt 'Ekiro kyona' \\
+        --max_new_tokens 100"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebooks for running data processing, training and testing on Google Colab
- update README with tips on running training on Colab vs local machine
- reference the new notebooks in the Google Colab setup guide

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ac6b2f4a0832bbdcc3835a282be09