### PR TITLE
Add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,22 @@ pdf2image
 datasets
 transformers
 torch
+# Additional libraries used throughout the processing scripts
+pytesseract
+PyPDF2
+pillow
+pydub
+requests
+beautifulsoup4
+
+# Web scraping and automation
+selenium==4.34.2
+webdriver-manager==4.0.2
+
+# System level utilities required for OCR, PDF and media processing
+# The following are system-level packages typically installed via apt or brew
+# They are listed here for completeness but will not be installed by pip
+# chromium-chromedriver
+# poppler-utils
+# tesseract-ocr
+# ffmpeg


### PR DESCRIPTION
## Summary
- add extra dependencies to `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_687b611c96d8832b85352d7dc048b8ba