### PR TITLE
Update training notebooks to use tokenizer

### DIFF
--- a/notebooks/02_Train_LLM_Stage1.ipynb
+++ b/notebooks/02_Train_LLM_Stage1.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "21d44d19",
    "metadata": {},
    "source": [
     "# LLM Training - Stage 1\n",
@@ -10,8 +11,9 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "d6bfbdff",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Clone repository if not already cloned\n",
@@ -21,18 +23,20 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "c54348ef",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Install dependencies\n",
-    "!pip install -r requirements.txt\n"
+    "!pip install -r requirements.txt"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "406270e6",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Mount Google Drive to load processed data and save models\n",
@@ -42,15 +46,17 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "4363de9f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Adjust the paths below if your data/model directories are in Drive\n",
-    "!python3 scripts/train_llm.py \\
-        --processed_data_path ./processed_data/processed_text \\
-        --model_name gpt2 \\
-        --output_dir ./models/runyoro_llm_model"
+    "!python3 scripts/train_llm.py \\\n",
+    "    --processed_data_path ./processed_data/processed_text \\\n",
+    "    --model_name gpt2 \\\n",
+    "    --output_dir ./models/runyoro_llm_model \\\n",
+    "    --tokenizer_dir ./tokenizer"
    ]
   }
  ],

--- a/notebooks/03_Test_LLM.ipynb
+++ b/notebooks/03_Test_LLM.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "82190ef9",
    "metadata": {},
    "source": [
     "# Test Trained LLM\n",
@@ -10,8 +11,9 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "334369b9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Clone repository if needed\n",
@@ -21,25 +23,39 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "1a8c7e53",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Install dependencies\n",
-    "!pip install -r requirements.txt\n"
+    "!pip install -r requirements.txt"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "e1c4e766",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mount Google Drive to load models\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "215e9a28",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load the model and generate text\n",
-    "!python3 scripts/test_llm.py \\
-        --model_path ./models/runyoro_llm_model/final_model \\
-        --prompt 'Ekiro kyona' \\
-        --max_new_tokens 100"
+    "!python3 scripts/test_llm.py \\\n",
+    "    --model_path ./models/runyoro_llm_model/final_model \\\n",
+    "    --prompt 'Ekiro kyona' \\\n",
+    "    --max_new_tokens 100"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- fix corrupted notebook format and regenerate Stage 1 training and testing notebooks
- pass `--tokenizer_dir` to training script
- ensure notebooks load correctly in Colab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687bac82cdac832b99f7779ba750e6ba