### PR TITLE
Improve GPT-2 training pipeline

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -1,0 +1,14 @@
+import subprocess, sys
+
+commands = [
+    [sys.executable, '-m', 'pip', 'uninstall', '-y', 'tensorflow', 'torch'],
+    [sys.executable, '-m', 'pip', 'install', 'torch==2.0.1', 'transformers==4.31.0', 'datasets==2.14.0', 'wandb==0.21.0'],
+]
+
+for cmd in commands:
+    subprocess.check_call(cmd)
+
+import torch
+assert torch.cuda.is_available(), "GPU not available"
+print(f"GPU: {torch.cuda.get_device_name(0)}")
+

--- a/train_colab.ipynb
+++ b/train_colab.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": ["from google.colab import drive\n", "drive.mount('/content/drive', force_remount=True)"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": ["%cd /content/drive/MyDrive/Runyoro_AI_Project/runyoro-llm-data-pipeline"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": ["!python3 setup_env.py\n", "!python3 -m scripts.train_llm \\\n    --processed_data_path ./processed_data/processed_text \\\n    --model_name gpt2 \\\n    --output_dir ./models/runyoro_llm_model_v2 \\\n    --tokenizer_dir ./tokenizer"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": ["!python3 scripts/test_llm.py \\\n    --model_path ./models/runyoro_llm_model_v2/final_model \\\n    --prompt 'Abaana ba Runyoro bagamba nti' \\\n    --max_new_tokens 100"]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}
+


### PR DESCRIPTION
## Summary
- tweak training defaults for longer runs and add warmup
- load dataset with `load_dataset` and make validation split
- allow model loading with mismatched sizes
- add W&B run name
- modernize generation in `test_llm.py` with `GenerationConfig`
- create environment setup script and Colab training notebook

## Testing
- `python -m py_compile scripts/train_llm.py scripts/test_llm.py setup_env.py`

------
https://chatgpt.com/codex/tasks/task_e_687ceb1957e8832b8d9f1cfcdea164e1