### PR TITLE
Prep scripts for MT5 training

### DIFF
--- a/scripts/tokenizer_utils.py
+++ b/scripts/tokenizer_utils.py
@@ -15,7 +15,7 @@ def _text_iterator(text_dir: str) -> Iterable[str]:
             logging.error(f"Error reading {path}: {e}")
 
 
-def train_tokenizer(processed_text_dir: str, tokenizer_dir: str, base_model_name: str = "gpt2", vocab_size: int = 5000):
+def train_tokenizer(processed_text_dir: str, tokenizer_dir: str, base_model_name: str = "google/mt5-small", vocab_size: int = 5000):
     """Train a tokenizer on all text files in ``processed_text_dir``.
 
     The tokenizer is initialized from ``base_model_name`` so special tokens match

--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -5,7 +5,7 @@ import shutil
 from datasets import Dataset, load_dataset
 from transformers import (
     AutoTokenizer,
-    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
     TrainingArguments,
     Trainer,
     DataCollatorForLanguageModeling,
@@ -68,6 +68,7 @@ def train_llm(
     dataset = load_dataset(
         "text",
         data_files=f"{processed_data_full_path}/*.txt",
+        cache_dir=cache_dir,
     )["train"]
     logging.info(f"Dataset size: {len(dataset)} examples")
 
@@ -207,7 +208,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model_name",
         type=str,
-        default="gpt2", # Start with a small, accessible model like GPT-2
+        default="google/mt5-small",
         help="Pre-trained model name from Hugging Face Transformers (e.g., gpt2, distilgpt2, facebook/opt-125m).",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- import `AutoModelForSeq2SeqLM`
- cache dataset downloads
- update default model name to `google/mt5-small`
- align tokenizer utility default base model

## Testing
- `python -m py_compile scripts/train_llm.py scripts/tokenizer_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687f462281e0832b8de42b18970a490c