### PR TITLE
Fix dataset cache path in training script

### DIFF
--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -68,7 +68,7 @@ def train_llm(
     dataset = load_dataset(
         "text",
         data_files=f"{processed_data_full_path}/*.txt",
-        cache_dir=cache_dir,
+        cache_dir="/tmp/hf_datasets_cache",
     )["train"]
     logging.info(f"Dataset size: {len(dataset)} examples")
 


### PR DESCRIPTION
## Summary
- specify `/tmp/hf_datasets_cache` for dataset cache directory
- confirm MT5 model defaults and tokenizer base model

## Testing
- `python3 -m py_compile scripts/train_llm.py scripts/tokenizer_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687f4992aa68832baed9f64d7c7d387d