### PR TITLE
Fix dataset loading with HF datasets 4

### DIFF
--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -68,7 +68,8 @@ def train_llm(
     dataset = load_dataset(
         "text",
         data_files=f"{processed_data_full_path}/*.txt",
-        cache_dir="/tmp/hf_datasets_cache",
+        cache_dir=cache_dir or "/tmp/hf_datasets_cache",
+        keep_in_memory=True,
     )["train"]
     logging.info(f"Dataset size: {len(dataset)} examples")
 


### PR DESCRIPTION
## Summary
- avoid LocalFileSystem error by loading text dataset into memory

## Testing
- `PYTHONPATH=. python scripts/train_llm.py --processed_data_path processed_data/processed_text --model_name distilgpt2 --output_dir /tmp/model_test --tokenizer_dir /tmp/token_test --num_train_epochs 1 --per_device_train_batch_size 1 --cache_dir /tmp/hf_cache --mixed_precision fp16` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_687f4db5ab68832b83a16b606b15dfad