### PR TITLE
Fix module import error in training notebook

### DIFF
--- a/notebooks/01_Process_Data.ipynb
+++ b/notebooks/01_Process_Data.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "# Run data processing\n",
-    "!python3 scripts/process_raw_data.py"
+    "!python3 -m scripts.process_raw_data"
    ]
   }
  ],

--- a/notebooks/02_Train_LLM_Stage1.ipynb
+++ b/notebooks/02_Train_LLM_Stage1.ipynb
@@ -1,1 +1,77 @@
-{"cells": [{"cell_type": "markdown", "id": "21d44d19", "metadata": {}, "source": ["# LLM Training - Stage 1\n", "Run the initial training of the model using GPU resources from Google Colab."]}, {"cell_type": "code", "execution_count": null, "id": "d6bfbdff", "metadata": {}, "outputs": [], "source": ["# Clone repository if not already cloned\n", "!git clone https://github.com/nyacly/runyoro-llm-data-pipeline.git || true\n", "%cd runyoro-llm-data-pipeline"]}, {"cell_type": "code", "execution_count": null, "id": "c54348ef", "metadata": {}, "outputs": [], "source": ["# Install dependencies\n", "!pip install -r requirements.txt"]}, {"cell_type": "code", "execution_count": null, "id": "406270e6", "metadata": {}, "outputs": [], "source": ["# Mount Google Drive to load processed data and save models\n", "from google.colab import drive\n", "drive.mount('/content/drive')"]}, {"cell_type": "code", "execution_count": null, "id": "4363de9f", "metadata": {}, "outputs": [], "source": ["!python3 scripts/train_llm.py \\", "    --processed_data_path ./processed_data/processed_text \\", "    --model_name gpt2 \\", "    --output_dir ./models/runyoro_llm_model \\", "    --tokenizer_dir ./tokenizer \\", "    --checkpoint_dir /content/runyoro_checkpoints \\", "    --mixed_precision fp16"]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python", "version": "3.x"}}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "21d44d19",
+   "metadata": {},
+   "source": [
+    "# LLM Training - Stage 1\n",
+    "Run the initial training of the model using GPU resources from Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6bfbdff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clone repository if not already cloned\n",
+    "!git clone https://github.com/nyacly/runyoro-llm-data-pipeline.git || true\n",
+    "%cd runyoro-llm-data-pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c54348ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "!pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "406270e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mount Google Drive to load processed data and save models\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4363de9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python3 -m scripts.train_llm \\",
+    "    --processed_data_path ./processed_data/processed_text \\",
+    "    --model_name gpt2 \\",
+    "    --output_dir ./models/runyoro_llm_model \\",
+    "    --tokenizer_dir ./tokenizer \\",
+    "    --checkpoint_dir /content/runyoro_checkpoints \\",
+    "    --mixed_precision fp16"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- make `scripts` a package so that imports work
- run processing and training scripts via the `-m` flag in example notebooks

## Testing
- `python -m scripts.test_pipeline`
- `python -m scripts.test_llm --model_path ./models/runyoro_llm_model/final_model --prompt 'test' --max_new_tokens 1` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name')*

------
https://chatgpt.com/codex/tasks/task_e_688160b3c0b0832b89e963ef25a5b114