### PR TITLE
Reduce warmup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ model isn't converging well.
 *   `--save_total_limit`: Number of checkpoints to keep (older ones are deleted).
 *   `--cleanup_checkpoints`: If set, the `checkpoint_dir` will be removed after the final model is copied to `output_dir`.
 *   `--mixed_precision`: Set to `fp16` or `bf16` to enable faster mixed‑precision training on GPU (recommended on Colab Pro+).
+*   `--warmup_steps`: Number of warm-up steps for the learning rate scheduler. Defaults to `5` so small datasets reach the base learning rate quickly.
 
 **Expected Results during Training:**
 

--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -26,7 +26,7 @@ def train_llm(
     save_total_limit: int = 2,
     logging_steps: int = 10,
     learning_rate: float = 1e-5,
-    warmup_steps: int = 500,
+    warmup_steps: int = 5,
     weight_decay: float = 0.01,
     eval_steps: int = 500,
     gradient_accumulation_steps: int = 1,
@@ -52,6 +52,9 @@ def train_llm(
     Experiment with ``learning_rate`` and ``gradient_accumulation_steps`` if the
     model is still not converging well after more epochs or data.
     Mixed precision (``fp16``) is enabled by default for faster training on GPUs.
+
+    ``warmup_steps`` now defaults to 5 so the scheduler quickly reaches the base
+    learning rate when training on small datasets.
     """
     logging.info(f"Loading dataset from {processed_data_path}")
 
@@ -302,7 +305,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--warmup_steps",
         type=int,
-        default=500,
+        default=5,
         help="Warmup steps for the scheduler.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- lower default warmup_steps to 5
- document short warmup default in train_llm docstring
- add warmup_steps explanation in README

## Testing
- `python -m py_compile scripts/train_llm.py`

------
https://chatgpt.com/codex/tasks/task_e_68819481c094832ba659e0ff88dbb9d1