### PR TITLE
Fix seq2seq tokenization for training

### DIFF
--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -105,7 +105,9 @@ def train_llm(
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})
 
     def tokenize_function(examples):
-        return tokenizer(examples["text"], truncation=True, max_length=512)
+        tokens = tokenizer(examples["text"], truncation=True, max_length=512)
+        tokens["labels"] = tokens["input_ids"].copy()
+        return tokens
 
     logging.info("Tokenizing dataset...")
     tokenized_datasets = dataset.map(


### PR DESCRIPTION
## Summary
- ensure the dataset supplies labels for seq2seq models

## Testing
- `python -m compileall -q scripts`

------
https://chatgpt.com/codex/tasks/task_e_68819c0bc760832ba039c42cc9fdb074