### PR TITLE
Add logging for warmup steps

### DIFF
--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -129,6 +129,7 @@ def train_llm(
         model.resize_token_embeddings(len(tokenizer))
 
     data_collator = DataCollatorForSeq2Seq(tokenizer=tokenizer, model=model)
+    logging.info("Using DataCollatorForSeq2Seq for training.")
 
     training_output_dir = checkpoint_dir if checkpoint_dir else output_dir
 
@@ -170,6 +171,9 @@ def train_llm(
     }
 
     training_args = TrainingArguments(**filtered_kwargs)
+    logging.info(
+        f"Actual warmup_steps used by Trainer: {training_args.warmup_steps}"
+    )
 
     trainer = Trainer(
         model=model,


### PR DESCRIPTION
## Summary
- log which data collator is used
- log the actual warmup steps passed to the Trainer

## Testing
- `pytest -q` *(fails: fixture 'model_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881cad87d14832b83daeddc4052017f