### PR TITLE
Handle ByT5 tokenizer correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python3 scripts/process_raw_data.py
 ```
 
 This script detects the file type (PDF, image, audio, video, or text) and calls the orchestrator accordingly. Processed outputs are saved in `processed_data/`, and metadata is written to `processed_data/processed_data_metadata.json`.
-After processing completes, a tokenizer is trained or updated using the text in `processed_data/processed_text/` and saved to `./tokenizer`. This tokenizer will be reused during LLM and ASR training.
+After processing completes, a tokenizer is trained or updated using the text in `processed_data/processed_text/` and saved to `./tokenizer`. This tokenizer will be reused during LLM and ASR training. If you choose a byte‑level model such as **ByT5**, no training is performed—the tokenizer is simply loaded from the base model.
 
 #### Example: Processing an Audio/Text Pair Directory
 


### PR DESCRIPTION
## Summary
- skip tokenizer training when ByT5 is used
- document that byte-level tokenizers like ByT5 skip the training step

## Testing
- `python3 -m py_compile scripts/tokenizer_utils.py scripts/train_llm.py`

------
https://chatgpt.com/codex/tasks/task_e_68820919e7cc832bb11adc1aee1e96d2