### PR TITLE
Add timeout to static website scraping

### DIFF
--- a/scripts/core_components.py
+++ b/scripts/core_components.py
@@ -44,7 +44,8 @@ def extract_text_from_image_ocr(image_or_path):
 
 def scrape_static_website(url):
     try:
-        response = requests.get(url)
+        # Use a timeout to avoid hanging indefinitely on slow or unresponsive servers
+        response = requests.get(url, timeout=10)
         response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
         main_content = soup.find("article") or soup.find("main") or soup.find("div", class_="content")


### PR DESCRIPTION
## Summary
- prevent indefinite hangs in `scrape_static_website`
- document a 10 second timeout for `requests.get`

## Testing
- `python3 -m py_compile scripts/core_components.py`


------
https://chatgpt.com/codex/tasks/task_e_688213a30b68832bb5e3f683e4ace239