### PR TITLE
Improve NaN handling in training

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,11 @@ experiencing numerical instability. The steps below summarize common fixes:
            raise ValueError("NaN found in input_ids")
    ```
 
-5. **Adjust training settings** – try smaller batch sizes and monitor logs (for
+5. **Ensure you have enough data** – training on an empty or tiny dataset can
+   produce zero or NaN gradients. Check that `processed_data/processed_text/`
+   contains non-empty `.txt` files before starting training.
+
+6. **Adjust training settings** – try smaller batch sizes and monitor logs (for
    example with TensorBoard) for early signs of divergence.
 
 ## Contributing

--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -130,6 +130,13 @@ def train_llm(
             raise
     logging.info(f"Dataset size: {len(dataset)} examples")
 
+    if len(dataset) == 0:
+        raise ValueError(
+            f"No training examples were found in {processed_data_full_path}."
+            " Ensure the directory contains non-empty .txt files before running"
+            " training."
+        )
+
     # Ensure we have a validation split
     dataset = dataset.train_test_split(test_size=0.1)
 


### PR DESCRIPTION
## Summary
- stop training if no text examples are found
- document the need for non-empty data in the NaN troubleshooting section

## Testing
- `python -m compileall -q scripts`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_6882bab25c88832b9e0e69f3ca027011