### PR TITLE
Fix tokenizer issue for ByT5 models

### DIFF
--- a/scripts/tokenizer_utils.py
+++ b/scripts/tokenizer_utils.py
@@ -2,9 +2,7 @@ import os
 import logging
 from pathlib import Path
 from typing import Iterable
-from transformers import T5TokenizerFast
-
-BYTE_LEVEL_TOKENIZERS = {"ByT5Tokenizer", "ByT5TokenizerFast"}
+from transformers import AutoTokenizer, ByT5Tokenizer
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
@@ -24,15 +22,15 @@ def train_tokenizer(processed_text_dir: str, tokenizer_dir: str, base_model_name
     the base model. The resulting tokenizer is saved to ``tokenizer_dir``.
     """
     logging.info(f"Training tokenizer from data in {processed_text_dir}")
-    tokenizer = T5TokenizerFast.from_pretrained(base_model_name)
+    tokenizer = AutoTokenizer.from_pretrained(base_model_name)
 
-    if tokenizer.__class__.__name__ in BYTE_LEVEL_TOKENIZERS:
+    if isinstance(tokenizer, ByT5Tokenizer):
         logging.info("ByT5 uses a fixed byte-level vocabulary; skipping tokenizer training.")
     else:
         iterator = _text_iterator(processed_text_dir)
         tokenizer = tokenizer.train_new_from_iterator(iterator, vocab_size=vocab_size)
 
-    os.makedirs(tokenizer_dir, exist_ok=T5TokenizerFast)
+    os.makedirs(tokenizer_dir, exist_ok=True)
     tokenizer.save_pretrained(tokenizer_dir)
     logging.info(f"Tokenizer saved to {tokenizer_dir}")
     return tokenizer


### PR DESCRIPTION
This commit fixes an issue where the tokenizer training would fail for ByT5 models. The `google/mt5-small` model now uses a `ByT5Tokenizer`, which is a byte-level tokenizer and does not need to be trained.

The `tokenizer_utils.py` script was modified to detect if the loaded tokenizer is a `ByT5Tokenizer`, and if so, skip the tokenizer training.