### PR TITLE
Fix dataset length calculation

### DIFF
--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -272,7 +272,9 @@ else:
 """
 
 # Adjust save and eval steps based on dataset size
-num_examples = len(train_dataset)
+# ``train_dataset`` may not be defined yet if earlier logic changes,
+# so base the calculation on ``tokenized_datasets`` directly.
+num_examples = len(tokenized_datasets["train"])
 if num_examples < 10000:
     save_steps = min(save_steps, 500)
     eval_steps = min(eval_steps, 250)


### PR DESCRIPTION
## Summary
- compute dataset length from tokenized dataset to avoid NameError

## Testing
- `python -m py_compile scripts/train_llm.py`


------
https://chatgpt.com/codex/tasks/task_e_68832a2b3ed8832ba695f16943f9fa1f