### PR TITLE
Fix CLI arg handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ python3 scripts/train_llm.py \
     --processed_data_path ./processed_data/processed_text \
     --model_name gpt2 \
     --output_dir ./models/runyoro_llm_model \
-    --tokenizer_dir ./tokenizer
-    --checkpoint_dir /content/runyoro_checkpoints
-    --mixed_precision fp16
+    --tokenizer_dir ./tokenizer \
+    --checkpoint_dir /content/runyoro_checkpoints \
+    --mixed_precision fp16 \
     --num_train_epochs 5 \
     --use_wandb
 ```

--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -528,7 +528,16 @@ if __name__ == "__main__":
         help="Disable mixed precision training (e.g., if encountering NaN gradients).",
     )
 
-    args = parser.parse_args()
+    # Use parse_known_args to gracefully handle any extra arguments
+    # that may get injected by environments like Jupyter or Colab.
+    # Unknown arguments are ignored but logged as a warning so the
+    # user is aware of potential typos or mismatches.
+    args, unknown_args = parser.parse_known_args()
+    if unknown_args:
+        logging.warning(
+            "Ignoring unrecognized arguments: %s",
+            " ".join(unknown_args),
+        )
     train_llm(
         processed_data_path=args.processed_data_path,
         model_name=args.model_name,


### PR DESCRIPTION
## Summary
- accept unknown CLI args gracefully
- fix training command formatting in README

## Testing
- `python3 -m py_compile scripts/train_llm.py`
- `find scripts -name '*.py' -print0 | xargs -0 python3 -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68834ba4777c832b9d11a0cc7cbc2ef8