### PR TITLE
I've updated the training notebook.

### DIFF
--- a/train_colab.ipynb
+++ b/train_colab.ipynb
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": ["!python3 setup_env.py\n", "!python3 -m scripts.train_llm \\\n    --processed_data_path ./processed_data/processed_text \\\n    --model_name gpt2 \\\n    --output_dir ./models/runyoro_llm_model_v2 \\\n    --tokenizer_dir ./tokenizer"]
+   "source": ["!python3 setup_env.py\n", "!python3 -m scripts.train_llm \\\n    --processed_data_path ./processed_data/processed_text \\\n    --model_name google/mt5-small \\\n    --output_dir ./models/runyoro_llm_model_v2 \\\n    --tokenizer_dir ./tokenizer \\\n    --no_mixed_precision \\\n    --use_wandb"]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
This commit fixes the training notebook by updating the training command to use the `google/mt5-small` model and to disable mixed precision. This ensures that the notebook is in sync with the rest of the codebase and that the training is stable.