### PR TITLE
Update Colab notebook training cell for Accelerate

### DIFF
--- a/train_colab.ipynb
+++ b/train_colab.ipynb
@@ -3,22 +3,45 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": ["from google.colab import drive\n", "drive.mount('/content/drive', force_remount=True)"]
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive', force_remount=True)"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": ["%cd /content/drive/MyDrive/Runyoro_AI_Project/runyoro-llm-data-pipeline"]
+   "source": [
+    "%cd /content/drive/MyDrive/Runyoro_AI_Project/runyoro-llm-data-pipeline"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": ["!python3 setup_env.py\n", "!python3 -m scripts.train_llm \\\n    --processed_data_path ./processed_data/processed_text \\\n    --model_name google/mt5-small \\\n    --output_dir ./models/runyoro_llm_model_v2 \\\n    --tokenizer_dir ./tokenizer \\\n    --no_mixed_precision \\\n    --use_wandb"]
+   "source": [
+    "!pip install transformers datasets accelerate\n",
+    "\n",
+    "# (After changing the runtime to GPU via Runtime \u2192 Change runtime type \u2192 GPU)\n",
+    "!nvidia-smi\n",
+    "\n",
+    "!accelerate config default\n",
+    "!accelerate launch scripts/train_llm.py \\\n  --processed_data_path processed_data/processed_text \\\n  --model_name_or_path google/mt5-small \\\n  --output_dir models/runyoro_llm_model \\\n  --num_train_epochs 3 \\\n  --per_device_train_batch_size 4 \\\n  --block_size 512\n"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": ["!python3 scripts/test_llm.py \\\n    --model_path ./models/runyoro_llm_model_v2/final_model \\\n    --prompt 'Abaana ba Runyoro bagamba nti' \\\n    --max_new_tokens 100"]
+   "source": [
+    "!python3 scripts/test_llm.py \\\n    --model_path ./models/runyoro_llm_model_v2/final_model \\\n    --prompt 'Abaana ba Runyoro bagamba nti' \\\n    --max_new_tokens 100"
+   ],
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {
@@ -33,4 +56,3 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
-


### PR DESCRIPTION
## Summary
- update training commands in `train_colab.ipynb` to use `accelerate`
- ensure notebook cells include required metadata

## Testing
- `python test_training_fix.py` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_68841355c6c4832b92153af74dd0607c