### PR TITLE
Add LoRA adapter snippet

### DIFF
--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -12,6 +12,7 @@ from transformers import (
     TrainerCallback,
     DataCollatorForLanguageModeling,
 )
+from peft import LoraConfig, get_peft_model
 from scripts.tokenizer_utils import train_tokenizer
 import math
 
@@ -233,6 +234,14 @@ def train_llm(
     model = AutoModelForSeq2SeqLM.from_pretrained(
         model_name, ignore_mismatched_sizes=True, **quant_args
     )
+    lora_cfg = LoraConfig(
+        r=8,
+        lora_alpha=32,
+        lora_dropout=0.05,
+        target_modules=['q', 'v'],
+        task_type='CAUSAL_LM',
+    )
+    model = get_peft_model(model, lora_cfg)
     if tokenizer.pad_token is not None and model.config.vocab_size < len(tokenizer):
         model.resize_token_embeddings(len(tokenizer))
     # HF Trainer setup using a causal language modeling collator


### PR DESCRIPTION
## Summary
- import `LoraConfig` and `get_peft_model` from `peft`
- configure LoRA adapters when loading the model in `train_llm.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688416eed80c832ba2ff5e49151e6c0d